### PR TITLE
Add funcionality to retrieve escaped particles

### DIFF
--- a/source/cpp/advect_particles.h
+++ b/source/cpp/advect_particles.h
@@ -8,8 +8,8 @@
 #define ADVECT_PARTICLES_H
 
 #include <Eigen/Dense>
-#include <vector>
 #include <memory>
+#include <vector>
 
 #include <dolfin/geometry/Point.h>
 
@@ -17,11 +17,12 @@
 
 namespace dolfin
 {
-  // Forward declarations
-  class FunctionSpace;
-  class Function;
-  class FiniteElement;
-  template<typename T> class MeshFunction;
+// Forward declarations
+class FunctionSpace;
+class Function;
+class FiniteElement;
+template <typename T>
+class MeshFunction;
 
 // enum for external facet types
 enum class facet_t : std::uint8_t
@@ -53,8 +54,7 @@ public:
   // Document
   advect_particles(
       particles& P, FunctionSpace& U,
-      std::function<const Function&(int, double)> uhi,
-      const std::string type1,
+      std::function<const Function&(int, double)> uhi, const std::string type1,
       Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic, 1>> pbc_limits);
 
   // Document
@@ -77,6 +77,15 @@ public:
       Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic, 1>> pbc_limits,
       Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic, 1>> bounded_limits);
 
+  // Assign escaped particles to buffer
+  void get_escaped_particles(double* buffer) const;
+
+  // Get number of escaped particles
+  size_t get_escaped_particles_size() const {return _escaped_particles.size();}
+
+  // Provide an interface to the particle template
+  std::vector<unsigned int> get_particle_template() const {return _P->ptemplate();}
+
   // Step forward in time dt
   void do_step(double dt);
 
@@ -91,6 +100,7 @@ public:
 protected:
   particles* _P;
 
+  void clear_escaped_particles() { _escaped_particles.clear(); }
   void set_bfacets(const std::string btype);
   void set_bfacets(const MeshFunction<std::size_t>& mesh_func);
 
@@ -147,7 +157,9 @@ protected:
   // Multi-stage scheme data
   std::size_t xp0_idx, up0_idx;
 
-  private:
+private:
+  // Collect the escaped particles
+  std::vector<particle> _escaped_particles;
 
   void update_particle_template()
   {
@@ -162,8 +174,6 @@ protected:
         _P->set_property(cidx, pidx, xp0_idx, _P->x(cidx, pidx));
     }
   }
-
-
 };
 
 class advect_rk2 : public advect_particles
@@ -205,7 +215,6 @@ public:
   void do_step(double dt);
 
 protected:
-
   void init_weights()
   {
     dti = {0.5, 0.5, 1.0, 1.0};

--- a/source/cpp/particles.h
+++ b/source/cpp/particles.h
@@ -57,8 +57,8 @@ public:
       for (unsigned int pidx = 0; pidx < num_cell_particles(cidx); ++pidx)
         _cell2part[cidx][pidx].push_back(p);
 
-  // Resize members for new number of properties
-  _empty_cell_property_values.resize(num_properties());
+    // Resize members for new number of properties
+    _empty_cell_property_values.resize(num_properties());
 
     return _ptemplate.size() - 1;
   }
@@ -71,6 +71,9 @@ public:
   // Pointer to the mesh
   const Mesh* mesh() const { return _mesh; }
 
+  // Get particle template
+  std::vector<unsigned int> ptemplate() const {return _ptemplate;}
+
   // Get size of property i
   unsigned int ptemplate(int i) const { return _ptemplate[i]; }
 
@@ -82,6 +85,11 @@ public:
 
   // Add particle to cell returning particle index
   int add_particle(int c);
+
+  particle get_particle(size_t cidx, size_t pidx)
+  {
+    return _cell2part[cidx][pidx];
+  }
 
   // Remove ith particle from cell c
   void delete_particle(int c, int i)
@@ -135,11 +143,11 @@ public:
   // If a cell has no particles, take the values from this cell function
   // as the default value in get_particle_contributions()
   void set_empty_cell_default_values(
-    std::shared_ptr<dolfin::MeshFunction<double>> cell_function,
-    const std::size_t property_idx)
+      std::shared_ptr<dolfin::MeshFunction<double>> cell_function,
+      const std::size_t property_idx)
   {
     if (_empty_cell_property_values.size() < num_properties())
-        _empty_cell_property_values.resize(num_properties());
+      _empty_cell_property_values.resize(num_properties());
 
     _empty_cell_property_values[property_idx] = cell_function;
   }
@@ -158,7 +166,7 @@ private:
   std::vector<unsigned int> _ptemplate;
   std::size_t _plen;
   std::vector<std::shared_ptr<dolfin::MeshFunction<double>>>
-    _empty_cell_property_values;
+      _empty_cell_property_values;
 
   // Needed for parallel
   const MPI_Comm _mpi_comm;


### PR DESCRIPTION
Add function `get_escaped_particles` to get the particles that escaped through open boundaries as an [nparticles x properties] numpy array.  It's not extremely elegant, but it should help one of the leopart users in a specific use case. 